### PR TITLE
Simple changes test chaining and fix an issue with valid_dbs

### DIFF
--- a/includes/resources/EFetch.inc
+++ b/includes/resources/EFetch.inc
@@ -2,13 +2,6 @@
 
 class EFetch extends EUtilsRequest{
 
-  protected $valid_dbs = [
-    'pubmed',
-    'bioproject',
-    'biosample',
-    'genome',
-  ];
-
   /**
    * EFetch constructor.
    *

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -2,30 +2,6 @@
 
 class EUtils{
 
-  ///**
-  // * Set the NCBI db.  Only the following DBs are allowed:
-  // * 'pubmed' - use the core publication importer instead.
-  // *
-  // * @param $db
-  // */
-  //public function setDB($db) {
-  //
-  //  $valid_dbs = array_flip($this->valid_dbs);
-  //
-  //  if (!array_key_exists($db, $valid_dbs)) {
-  //    tripal_set_message('Invalid db: !db', [!'db' => $db], TRIPAL_ERROR);
-  //    return FALSE;
-  //  }
-  //
-  //  $this->db = $db;
-  //  //if db isn't supported by efetch, do something...
-  //
-  //  if ($db == 'assembly') {
-  //    $this->url = 'https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?';
-  //  }
-  //  return TRUE;
-  //}
-
   /**
    * Search the set DB for the provided accessions
    *
@@ -36,15 +12,12 @@ class EUtils{
    * @throws \Exception
    */
   public function lookupAccessions($db, array $accessions) {
-    $provider = $this->getResourceProvider($db);
     $accessions = implode(',', $accessions);
-    $provider->addParam('id', $accessions);
 
-    if ($db !== 'assembly') {
-      $provider->addParam('retmode', 'xml')->addParam('rettype', 'xml');
-    }
+    $response = $this->getResourceProvider($db)
+      ->addParam('id', $accessions)
+      ->get();
 
-    $response = $provider->get();
     if ($response->isSuccessful()) {
       return $response->xml();
     }

--- a/includes/xml_parsers/EutilsXMLParser.inc
+++ b/includes/xml_parsers/EutilsXMLParser.inc
@@ -93,6 +93,12 @@ class EutilsXMLParser{
     return $info;
   }
 
+  /**
+   * @param $xml
+   *
+   * @return array
+   * @throws \Exception
+   */
   private function bioprojectProject($xml) {
     $info = [];
 
@@ -137,9 +143,7 @@ class EutilsXMLParser{
           break;
 
         default:
-          //Unexpected tag.  throw an error.
-          tripal_log(t("Unexpected tag: !key", ['!key' => $key]));
-          return FALSE;
+          throw new Exception('Unknown tag '.$key);
       }
     }
 

--- a/tests/EutilsXmlParserTest.php
+++ b/tests/EutilsXmlParserTest.php
@@ -125,6 +125,7 @@ class EutilsXmlParserTest extends TripalTestCase{
 
     $xml = simplexml_load_string($string);
 
+    $this->expectException('Exception');
     $parser_r = reflect($parser);
     $submission_info = $parser_r->bioprojectProject($xml);
     $this->assertFalse($submission_info);


### PR DESCRIPTION
- Instead of returning false, throw an exception
- Remove valid_dbs variable from the EFetch class since it's been moved to EUtils
- Remove unneeded params from accessions request 