### PR TITLE
standardize full xml prop location and add test

### DIFF
--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -32,6 +32,9 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function create($data) {
 
+
+    $this->createXMLProp($data['full_ncbi_xml']);
+
   }
 
 }

--- a/includes/repositories/EUtilsBioProjectRepository.php
+++ b/includes/repositories/EUtilsBioProjectRepository.php
@@ -54,6 +54,11 @@ class EUtilsBioProjectRepository extends EUtilsRepository{
     $this->createAccessions($data['accessions']);
 
     $this->createProps($data['attributes']);
+
+    //add xml
+
+    $this->createXMLProp($data['full_ncbi_xml']);
+
     return $project;
   }
 

--- a/includes/repositories/EUtilsBioSampleRepository.php
+++ b/includes/repositories/EUtilsBioSampleRepository.php
@@ -55,6 +55,8 @@ class EUtilsBioSampleRepository extends EUtilsRepository {
 
     // Create the props (from attributes)
     $this->createProps($data['attributes']);
+    $this->createXMLProp($data['full_ncbi_xml']);
+
 
     return $bio_sample;
   }

--- a/includes/repositories/EUtilsRepository.php
+++ b/includes/repositories/EUtilsRepository.php
@@ -235,6 +235,11 @@ abstract class EUtilsRepository {
 
   }
 
+  /**
+   * Associates the XML with the record via the local:full_ncbi_xml term.
+   * @param $xml
+   * xml string as returned by simpleXML.
+   */
   public function createXMLProp($xml) {
 
     $xml_term = tripal_get_cvterm(['id' => 'local:full_ncbi_xml']);

--- a/includes/repositories/EUtilsRepository.php
+++ b/includes/repositories/EUtilsRepository.php
@@ -234,4 +234,12 @@ abstract class EUtilsRepository {
     chado_associate_dbxref($this->base_table, $this->base_record_id, $dbxref);
 
   }
+
+  public function createXMLProp($xml) {
+
+    $xml_term = tripal_get_cvterm(['id' => 'local:full_ncbi_xml']);
+
+    $this->createProperty($xml_term->cvterm_id, $xml);
+
+  }
 }

--- a/includes/xml_parsers/EUtilsAssemblyParser.inc
+++ b/includes/xml_parsers/EUtilsAssemblyParser.inc
@@ -14,6 +14,9 @@ class EUtilsAssemblyParser implements EUtilsParserInterface {
     $xml = $xml->DocumentSummary;
 
     $children = $xml->children();
+
+    $info['full_ncbi_xml'] = $xml->asXML();
+
     foreach ($children as $key => $child) {
 
       switch ($key) {

--- a/includes/xml_parsers/EUtilsBioProjectParser.inc
+++ b/includes/xml_parsers/EUtilsBioProjectParser.inc
@@ -21,6 +21,7 @@ class EUtilsBioProjectParser implements EUtilsParserInterface {
       'attributes' => [],
       //Expected keys for linked records:  Contact, biomaterial, analysis, organism
       'linked_records' => [],
+      'full_ncbi_xml' => ''
     ];
 
 
@@ -34,7 +35,7 @@ class EUtilsBioProjectParser implements EUtilsParserInterface {
 
       throwException($e);
     }
-    $info['attributes']['full_ncbi_xml'] = $project->asXML();
+    $info['full_ncbi_xml'] = $project->asXML();
 
     $children = $project->children();
     foreach ($children as $key => $child) {

--- a/includes/xml_parsers/EUtilsBioSampleParser.inc
+++ b/includes/xml_parsers/EUtilsBioSampleParser.inc
@@ -18,6 +18,7 @@ class EUtilsBioSampleParser implements EUtilsParserInterface{
       'accessions' => $accessions,
       'description' => isset($xml->BioSample->Description->Comment) ? $this->extractParagraphs($xml->BioSample->Description->Comment) : [],
       'attributes' => $this->extractAttributes($xml->BioSample->Attributes),
+      'full_ncbi_xml' => $xml->BioSample->asXML()
     ];
 
     return $data;

--- a/tests/EUtilsBioProjectRepositoryTest.php
+++ b/tests/EUtilsBioProjectRepositoryTest.php
@@ -66,6 +66,20 @@ class EUtilsBioProjectRepositoryTest extends TripalTestCase {
     //at a minimum we have the raw XML prop.
     $this->assertNotEmpty($props);
 
+
+
+    $xml_term = tripal_get_cvterm(['id' => 'local:full_ncbi_xml']);
+
+
+    $props = db_select('chado.projectprop', 't')
+      ->fields('t')
+      ->condition('t.project_id', $result->project_id)
+      ->condition('t.type_id', $xml_term->cvterm_id)
+      ->execute()
+      ->fetchObject();
+
+    //at a minimum we have the raw XML prop.
+    $this->assertNotFalse($props);
   }
 
 }


### PR DESCRIPTION
resolve #33 

Note I define a "create xml" method `createXMLProp` in the base class, its then up to each extended class to call it in its `create` method...