### PR TITLE
Use ftp in assembly class

### DIFF
--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -16,6 +16,11 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     'timeexecuted' => '',
   ];
 
+  /**
+   * The fields expected from the XML parser.
+   * 
+   * @var array
+   */
   protected $required_fields = [
     'name',
     'description',
@@ -87,7 +92,7 @@ $this->validateFields($data);
     $this->createXMLProp($data['full_ncbi_xml']);
 
   //  $mapper = new TagMapper();
-    
+
     //add "stats" as properties
     foreach ($data['attributes']['stats'] as $key => $value) {
 

--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -2,14 +2,20 @@
 
 class EUtilsAssemblyRepository extends EUtilsRepository {
 
+
   /**
-   * Required attributes when using the create method.
+   * chado base table Analysis record.
    *
    * @var array
    */
-  protected $required_fields = [
-
+  protected $base_fields = [
+    'name' => '',
+    'description' => '',
+    'program' => '',
+    'programversion' => '',
+    'timeexecuted' => '',
   ];
+
 
   /**
    * Cache of data per run.
@@ -32,16 +38,119 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function create($data) {
 
+    $name = $data['name'];
+
+    $description = $data['description'];
+
     //program and program version come from # Assembly method: $data['attributes']['ftp_attributes']['# Assembly method:']
 
     $method_string = $data['attributes']['ftp_attributes']['# Assembly method:'];
 
-    var_dump($method_string);
+    //TODO: what do we want to do here?  Parse out the verion from the assembly program?  But what if we have multiple programs and versions returned, what then?
+    $program = $method_string;
+    $programvesion = $method_string;
 
+
+    //TODO: missing:
+    //algorithm, sourcename, sourceversion, sourceuri, timeexecuted.
+
+
+
+    $this->base_fields = [
+      'name' => $name,
+      'description' => $description,
+      'program' => $program,
+      'programversion' => $programvesion,
+      'timeexecuted' => date_now(),
+    ];
+
+
+    $analysis = $this->createAnalysis();
+
+    //Set class base record stuff
+    $this->base_table = 'analysis';
+    $this->base_record_id = $analysis->analysis_id;
+
+
+    //Set the type of the analysis so it maps to a bundle.
+    //consider: genome assembly, transcriptome, etc.
+    //TODO: do we let users map which analysis to create?
+    $term = tripal_get_cvterm(['id' => 'rdfs:type']);
+    $this->createProperty($term->cvterm_id, 'genome_assembly');
     $this->createXMLProp($data['full_ncbi_xml']);
+
+    return $analysis;
 
   }
 
 
+  public function createAnalysis() {
+    // Name is unique so find project.
+    $record = $this->getAnalysis();
+
+    if (!empty($record)) {
+      return $record;
+    }
+
+    $base = $this->base_fields;
+
+    $id = db_insert('chado.analysis')->fields([
+      'name' => $base['name'],
+      'description' => $base['description'] ?? '',
+      'program' => $base['program'],
+      'programversion' => $base['programversion'],
+      'algorithm' => $base['algorithm'] ?? '',
+      'sourcename' => $base['sourcename'] ?? '',
+      'sourceversion' => $base['sourceversion'] ?? '',
+      'sourceuri' => $base['sourceuri'] ?? '',
+      'timeexecuted' => $base['timeexecuted'] ?? date_now(),
+    ])->execute();
+
+    if (!$id) {
+      throw new Exception('Unable to create chado.analysis record');
+    }
+
+    $analysis = db_select('chado.analysis', 't')
+      ->fields('t')
+      ->condition('analysis_id', $id)
+      ->execute()
+      ->fetchObject();
+
+    return static::$cache['analysis'] = $analysis;
+  }
+
+  /**
+   * Get analysis from db or cache.
+   *
+   * @param string $name
+   *
+   * @return null
+   */
+  public function getAnalysis() {
+
+    $base = $this->base_fields;
+    // If the project is available in our static cache, return it
+    if (isset(static::$cache['analysis'])) {
+      return static::$cache['analysis'];
+    }
+
+
+    $exists = db_select('chado.analysis', 't')
+      ->fields('t')
+      ->condition('name', $base['name'])
+      ->condition('program', $base['program'])
+      ->condition('programversion', $base['programversion'])
+      ->execute()
+      ->fetchObject();
+
+    if ($exists) {
+
+      //TODO: we need to carefully validate the returned analysis.  We want to be sure we arent overwriting another existing analysis....
+
+      return static::$cache['analysis'] = $exists;
+    }
+
+    return NULL;
+  }
 
 }

--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -32,9 +32,16 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function create($data) {
 
+    //program and program version come from # Assembly method: $data['attributes']['ftp_attributes']['# Assembly method:']
+
+    $method_string = $data['attributes']['ftp_attributes']['# Assembly method:'];
+
+    var_dump($method_string);
 
     $this->createXMLProp($data['full_ncbi_xml']);
 
   }
+
+
 
 }

--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -55,7 +55,6 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     //algorithm, sourcename, sourceversion, sourceuri, timeexecuted.
 
 
-
     $this->base_fields = [
       'name' => $name,
       'description' => $description,
@@ -78,6 +77,27 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     $term = tripal_get_cvterm(['id' => 'rdfs:type']);
     $this->createProperty($term->cvterm_id, 'genome_assembly');
     $this->createXMLProp($data['full_ncbi_xml']);
+
+  //  $mapper = new TagMapper();
+
+
+    var_dump($data['attributes']);
+    //add "stats" as properties
+    foreach ($data['attributes']['stats'] as $key => $value) {
+
+      //TODO: use mapper to look up cvterms.
+      //for now just use local.
+      // $mapper->lookupAttribute($key)
+      $term = tripal_insert_cvterm([
+        'id' => 'ncbi_properties:' . $key,
+        'name' => $key,
+        'def' => '',
+        'cv_name' => 'ncbi_properties',
+      ]);
+      $this->createProperty($term->cvterm_id, $value);
+    }
+
+    //TODO: add FTP links.
 
     return $analysis;
 

--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -16,6 +16,14 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     'timeexecuted' => '',
   ];
 
+  protected $required_fields = [
+    'name',
+    'description',
+    'attributes',
+    'full_ncbi_xml'
+
+  ];
+
 
   /**
    * Cache of data per run.
@@ -79,9 +87,7 @@ $this->validateFields($data);
     $this->createXMLProp($data['full_ncbi_xml']);
 
   //  $mapper = new TagMapper();
-
-
-    var_dump($data['attributes']);
+    
     //add "stats" as properties
     foreach ($data['attributes']['stats'] as $key => $value) {
 

--- a/includes/repositories/EUtilsAssemblyRepository.php
+++ b/includes/repositories/EUtilsAssemblyRepository.php
@@ -37,7 +37,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    * @return object|void
    */
   public function create($data) {
-
+$this->validateFields($data);
     $name = $data['name'];
 
     $description = $data['description'];

--- a/includes/repositories/EUtilsRepository.php
+++ b/includes/repositories/EUtilsRepository.php
@@ -230,13 +230,13 @@ abstract class EUtilsRepository {
       'accession' => $accession,
       'db_id' => $db_id,
     ];
-
     chado_associate_dbxref($this->base_table, $this->base_record_id, $dbxref);
 
   }
 
   /**
    * Associates the XML with the record via the local:full_ncbi_xml term.
+   *
    * @param $xml
    * xml string as returned by simpleXML.
    */

--- a/includes/xml_parsers/EUtilsAssemblyParser.inc
+++ b/includes/xml_parsers/EUtilsAssemblyParser.inc
@@ -1,6 +1,6 @@
 <?php
 
-class EUtilsAssemblyParser implements EUtilsParserInterface{
+class EUtilsAssemblyParser implements EUtilsParserInterface {
 
   /**
    * @param \SimpleXMLElement $xml
@@ -22,6 +22,7 @@ class EUtilsAssemblyParser implements EUtilsParserInterface{
       switch ($key) {
         case 'Meta':
           $info['attributes'] = $this->parseMeta($child);
+
           break;
 
         case 'AssemblyName':
@@ -80,6 +81,11 @@ class EUtilsAssemblyParser implements EUtilsParserInterface{
       }
     }
 
+    $url = $list['files']['Assembly_rpt'] ?? NULL;
+
+    if ($url) {
+      $list['ftp_attributes'] = $this->getFTPData($url);
+    }
     return $list;
   }
 
@@ -112,4 +118,32 @@ class EUtilsAssemblyParser implements EUtilsParserInterface{
 
     return $results;
   }
+
+  /**
+   * Get the fields the assembly object will need from the FTP.
+   *
+   * @param $url - the ftp site url extracted form the metadata
+   *
+   * @return array
+   *
+   */
+  private function getFTPData($url) {
+
+    $ftp = new EFTP();
+
+    $ftp->setURL($url);
+
+    $data = [];
+
+    $fields = ['# Assembly method:'];
+
+    foreach ($fields as $field) {
+      $value = $ftp->getField($field);
+
+      $data[$field] = $value;
+    }
+
+    return $data;
+  }
+
 }

--- a/includes/xml_parsers/EUtilsAssemblyParser.inc
+++ b/includes/xml_parsers/EUtilsAssemblyParser.inc
@@ -138,7 +138,15 @@ class EUtilsAssemblyParser implements EUtilsParserInterface {
     $fields = ['# Assembly method:'];
 
     foreach ($fields as $field) {
-      $value = $ftp->getField($field);
+      $values = $ftp->getField($field);
+
+      if (count($values === 0)) {
+
+        $value = $values[0];
+      }
+      else {
+        $value = implode('', $values);
+      }
 
       $data[$field] = $value;
     }

--- a/includes/xml_parsers/EUtilsAssemblyParser.inc
+++ b/includes/xml_parsers/EUtilsAssemblyParser.inc
@@ -127,9 +127,11 @@ class EUtilsAssemblyParser implements EUtilsParserInterface {
    * @return array
    *
    */
-  private function getFTPData($url) {
+  public function getFTPData($url) {
 
     $ftp = new EFTP();
+
+    var_dump("im being called for " . $url);
 
     $ftp->setURL($url);
 

--- a/includes/xml_parsers/EUtilsAssemblyParser.inc
+++ b/includes/xml_parsers/EUtilsAssemblyParser.inc
@@ -86,6 +86,7 @@ class EUtilsAssemblyParser implements EUtilsParserInterface {
     if ($url) {
       $list['ftp_attributes'] = $this->getFTPData($url);
     }
+
     return $list;
   }
 
@@ -130,8 +131,6 @@ class EUtilsAssemblyParser implements EUtilsParserInterface {
   public function getFTPData($url) {
 
     $ftp = new EFTP();
-
-    var_dump("im being called for " . $url);
 
     $ftp->setURL($url);
 

--- a/tests/BiosamplePropertyLookupTest.php
+++ b/tests/BiosamplePropertyLookupTest.php
@@ -5,7 +5,7 @@ namespace Tests;
 use StatonLab\TripalTestSuite\DBTransaction;
 use StatonLab\TripalTestSuite\TripalTestCase;
 
-class BiosamplePropertyLookupTest extends TripalTestCase{
+class BiosamplePropertyLookupTest extends TripalTestCase {
 
   // Uncomment to auto start and rollback db transactions per test method.
   // use DBTransaction;
@@ -19,11 +19,12 @@ class BiosamplePropertyLookupTest extends TripalTestCase{
     $this->assertNotEmpty($terms);
 
     // Version 1.0 as of November 29 2018: 456 terms.
+    //has this number changed?  That's OK but create an issue, we want to track these changes.
     $this->assertEquals(456, count($terms));
   }
 
   /**
-   * Random example of a term that should have been installed ni hte XML
+   * Random example of a term that should have been installed in the XML
    * reading.
    *
    * @group terms

--- a/tests/EUtilsAssemblyRepositoryTest.php
+++ b/tests/EUtilsAssemblyRepositoryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+class EUtilsAssemblyRepositoryTest extends TripalTestCase {
+
+  // Uncomment to auto start and rollback db transactions per test method.
+   use DBTransaction;
+
+
+  /**
+   * @group analysis
+   * @group assembly
+   * @group repository
+   * @group wip
+   */
+  public function testAssemblyFromXML() {
+
+
+    $file = __DIR__ . '/../examples/assembly/559011_assembly.xml';
+
+    $parser = new \EUtilsAssemblyParser();
+    $assembly = $parser->parse(simplexml_load_file($file));
+
+    $repo = new \EUtilsAssemblyRepository();
+
+    // Make sure creating a new one works
+    $name = 'wgs.5d';
+    $result = $repo->create($assembly);
+
+    $this->assertObjectHasAttribute('analysis_id', $result);
+
+
+    $props = db_select('chado.analysisprop', 't')
+      ->fields('t')
+      ->condition('t.analysis_id', $result->analysis_id)
+      ->execute()
+      ->fetchAll();
+
+    //at a minimum we have the raw XML prop.
+    $this->assertNotEmpty($props);
+
+    $xml_term = tripal_get_cvterm(['id' => 'local:full_ncbi_xml']);
+
+
+    $props = db_select('chado.analysisprop', 't')
+      ->fields('t')
+      ->condition('t.analysis_id', $result->analysis_id)
+      ->condition('t.type_id', $xml_term->cvterm_id)
+      ->execute()
+      ->fetchObject();
+
+    //at a minimum we have the raw XML prop.
+    $this->assertNotFalse($props);
+  }
+}

--- a/tests/EUtilsAssemblyRepositoryTest.php
+++ b/tests/EUtilsAssemblyRepositoryTest.php
@@ -8,7 +8,7 @@ use StatonLab\TripalTestSuite\TripalTestCase;
 class EUtilsAssemblyRepositoryTest extends TripalTestCase {
 
   // Uncomment to auto start and rollback db transactions per test method.
-   use DBTransaction;
+  use DBTransaction;
 
 
   /**
@@ -22,11 +22,21 @@ class EUtilsAssemblyRepositoryTest extends TripalTestCase {
 
     $file = __DIR__ . '/../examples/assembly/559011_assembly.xml';
 
-    $parser = new \EUtilsAssemblyParser();
+
+    $parser = $this->getMockBuilder('\EUtilsAssemblyParser')
+      ->setMethods(['getFTPData'])
+      ->getMock();
+
+    //We mock the FTP call.
+    $ftp_response = ['# Assembly method:' => 'a method, v1.0'];
+
+    $parser->expects($this->once())
+      ->method('getFTPData')
+      ->will($this->returnValue($ftp_response));
+
     $assembly = $parser->parse(simplexml_load_file($file));
-
+    
     $repo = new \EUtilsAssemblyRepository();
-
     // Make sure creating a new one works
     $name = 'wgs.5d';
     $result = $repo->create($assembly);

--- a/tests/EUtilsXmlParserTest.php
+++ b/tests/EUtilsXmlParserTest.php
@@ -121,19 +121,15 @@ class EUtilsXmlParserTest extends TripalTestCase {
 
   public function testAssemblyParser($path, $base_keys) {
 
-    //Note:  the FTP call slows down the test.
-$parser = new \EUtilsAssemblyParser();
 
-//
-//    $parser = $this->getMockBuilder('\EUtilsAssemblyParser')
-//    ->setMethods()
-//    ->getMock();
-//
-//    $ftp_response = [['# Assembly method:' => 'a method, v1.0']];
-//
-//    $parser->expects($this->once())
-//      ->method('getFTPData')
-//      ->will($this->returnValue($ftp_response));
+    $parser = $this->getMockBuilder('\EUtilsAssemblyParser')
+      ->setMethods(['getFTPData'])
+      ->getMock();
+    //We mock the FTP call to speed up the test.
+    $ftp_response = ['# Assembly method:' => 'a method, v1.0'];
+    $parser->expects($this->once())
+      ->method('getFTPData')
+      ->will($this->returnValue($ftp_response));
 
     $assembly = $parser->parse(simplexml_load_file($path));
 
@@ -149,7 +145,7 @@ $parser = new \EUtilsAssemblyParser();
     $this->assertArrayHasKey('stats', $attributes);
     $this->assertArrayHasKey('files', $attributes);
     $this->assertArrayHasKey('ftp_attributes', $attributes);
-
+    
     $this->assertArrayHasKey('# Assembly method:', $attributes['ftp_attributes']);
     $this->assertNotNull($attributes['ftp_attributes']['# Assembly method:']);
 

--- a/tests/EUtilsXmlParserTest.php
+++ b/tests/EUtilsXmlParserTest.php
@@ -73,7 +73,7 @@ class EUtilsXmlParserTest extends TripalTestCase {
       /**
        * These will be used to lookup biosamples and assemblies.
        */
-      if (isset($linked_records['locus_tag_prefix'])){
+      if (isset($linked_records['locus_tag_prefix'])) {
         $locus_tag = $linked_records['locus_tag_prefix'];
 
         $this->assertArrayHasKey('value', $locus_tag);
@@ -136,12 +136,16 @@ class EUtilsXmlParserTest extends TripalTestCase {
 
     $this->assertArrayHasKey('stats', $attributes);
     $this->assertArrayHasKey('files', $attributes);
+    $this->assertArrayHasKey('ftp_attributes', $attributes);
 
+    $this->assertArrayHasKey('# Assembly method:', $attributes['ftp_attributes']);
+    $this->assertNotNull($attributes['ftp_attributes']['# Assembly method:']);
 
     $this->assertNotNull($assembly['name']);
     $this->assertNotNull($assembly['accessions']);
     $this->assertNotNull($assembly['attributes']);
     $this->assertNotNull($assembly['description']);
+
 
   }
 

--- a/tests/EUtilsXmlParserTest.php
+++ b/tests/EUtilsXmlParserTest.php
@@ -121,8 +121,20 @@ class EUtilsXmlParserTest extends TripalTestCase {
 
   public function testAssemblyParser($path, $base_keys) {
 
+    //Note:  the FTP call slows down the test.
+$parser = new \EUtilsAssemblyParser();
 
-    $parser = new \EUtilsAssemblyParser();
+//
+//    $parser = $this->getMockBuilder('\EUtilsAssemblyParser')
+//    ->setMethods()
+//    ->getMock();
+//
+//    $ftp_response = [['# Assembly method:' => 'a method, v1.0']];
+//
+//    $parser->expects($this->once())
+//      ->method('getFTPData')
+//      ->will($this->returnValue($ftp_response));
+
     $assembly = $parser->parse(simplexml_load_file($path));
 
     $this->assertArrayHasKey('name', $assembly);


### PR DESCRIPTION
* use the FTP class to parse for the analysis program info and use that in the analysis base record.
this slows down the analysis test a LOT because we do it for every XML.  we should probably note run all xml imports on travis for that reason or find a way to mock it/not query the FTP in travis.