### PR TITLE
Test all factories

### DIFF
--- a/includes/repositories/EUtilsRepositoryFactory.inc
+++ b/includes/repositories/EUtilsRepositoryFactory.inc
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Class EutilsRepositoryFactory.
+ * Class EUtilsRepositoryFactory.
  */
-class EutilsRepositoryFactory implements EUtilsFactoryInterface {
+class EUtilsRepositoryFactory implements EUtilsFactoryInterface {
 
   /**
    * DB to repository mapping.

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -63,7 +63,7 @@ class EUtils {
       return $data;
     }
 
-    $repository = (new EutilsRepositoryFactory())->get($db);
+    $repository = (new EUtilsRepositoryFactory())->get($db);
 
     $record = $repository->create($data);
 

--- a/tests/EUtilsFactoriesTest.php
+++ b/tests/EUtilsFactoriesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests;
+
+use StatonLab\TripalTestSuite\DBTransaction;
+use StatonLab\TripalTestSuite\TripalTestCase;
+
+/**
+ * Class EUtilsFactoriesTest.
+ *
+ * @package Tests
+ */
+class EUtilsFactoriesTest extends TripalTestCase {
+
+  // Uncomment to auto start and rollback db transactions per test method.
+  use DBTransaction;
+
+  /**
+   * @var array
+   */
+  protected $valid_dbs = [
+    'biosample',
+    'bioproject',
+    'assembly',
+  ];
+
+  /**
+   * @var array
+   */
+  protected $invalid_dbs = [
+    'not_in_a_million_years',
+  ];
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsRepositoryFactoryReturnsARepository() {
+    foreach ($this->valid_dbs as $db) {
+      $repo = (new \EUtilsRepositoryFactory())->get($db);
+      $this->assertInstanceOf(\EUtilsRepository::class, $repo);
+    }
+  }
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsRepositoryFactoryThrowsAnExceptionWithInvalidDBs() {
+    foreach ($this->invalid_dbs as $db) {
+      $this->expectException(\Exception::class);
+      (new \EUtilsRepositoryFactory())->get($db);
+    }
+  }
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsFormatterFactoryReturnsAFormatter() {
+    // Foreach ($this->valid_dbs as $db) {.
+    // TODO: rewrite the test for all dbs once the formatters are ready.
+    $db = 'biosample';
+    $formatter = (new \EUtilsFormatterFactory())->get($db);
+    $this->assertInstanceOf(\EUtilsFormatter::class, $formatter);
+    // }.
+  }
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsFormatterFactoryThrowsAnExceptionWithInvalidDBs() {
+    foreach ($this->invalid_dbs as $db) {
+      $this->expectException(\Exception::class);
+      (new \EUtilsFormatterFactory())->get($db);
+    }
+  }
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsXMLParserFactoryReturnsAnXMLParser() {
+    foreach ($this->valid_dbs as $db) {
+      $formatter = (new \EUtilsXMLParserFactory())->get($db);
+      $this->assertInstanceOf(\EUtilsParserInterface::class, $formatter);
+    }
+  }
+
+  /**
+   * @group factory
+   * @throws \Exception
+   */
+  public function testThatEUtilsXMLParserFactoryThrowsAnExceptionWithInvalidDBs() {
+    foreach ($this->invalid_dbs as $db) {
+      $this->expectException(\Exception::class);
+      (new \EUtilsXMLParserFactory())->get($db);
+    }
+  }
+
+}

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -25,7 +25,7 @@ require_once 'includes/xml_parsers/EUtilsBioProjectParser.inc';
 require_once 'includes/xml_parsers/EUtilsAssemblyParser.inc';
 
 // Repositories. Handling DB operations.
-require_once 'includes/repositories/EutilsRepositoryFactory.inc';
+require_once 'includes/repositories/EUtilsRepositoryFactory.inc';
 require_once 'includes/repositories/EUtilsRepository.inc';
 require_once 'includes/repositories/EUtilsBioSampleRepository.inc';
 require_once 'includes/repositories/EUtilsBioProjectRepository.inc';


### PR DESCRIPTION
Verifies that all factories return the appropriate type of classes. Helpful if in the future we introduce new parsers, repositories and/or formatters.