### PR TITLE
Clarify accessions

### DIFF
--- a/includes/repositories/EUtilsBioSampleRepository.inc
+++ b/includes/repositories/EUtilsBioSampleRepository.inc
@@ -175,8 +175,6 @@ class EUtilsBioSampleRepository extends EUtilsRepository {
   /**
    * Creates a set of accessions attaches them with the given biosample.
    *
-   * @param object $bio_sample
-   *   The BioSample created by createBioSample()
    * @param array $accessions
    *
    * @return array

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -61,10 +61,12 @@ class EUtils {
    * @throws \Exception
    */
   public function get($db, $accession) {
+    $accession = $this->convertAccessionsToUID($db, $accession);
 
     if (isset(static::$visited[$db][$accession])) {
       return static::$visited[$db][$accession];
     }
+
 
     $provider = $this->getResourceProvider($db);
     $provider->addParam('id', $accession);
@@ -137,4 +139,39 @@ class EUtils {
     return new EFetch($db);
   }
 
+
+  /**
+   * Checks the accession and converts to uid accession if neccesary.
+   *
+   * @param string $accession
+   * The accession for the NCBI record.
+   *
+   * @return string
+   */
+  private function convertAccessionsToUID(string $db, string $accession) {
+
+
+    if (preg_match("/[a-z]/i", $accession)) {
+
+      //We have letters and need to convert to uid.
+
+      $provider = new ESearch($db);
+      $provider->addParam('retmode', 'xml');
+      $provider->addParam('term', $accession);
+      $response = $provider->get();
+
+      //TODO handle no response here.
+
+      $xml = $response->xml();
+
+      $count = (int) $xml->Count;
+      if ($count > 1) {
+        print("warning more than one result");
+        return FALSE;
+      }
+      $accession = (string) $xml->IdList->Id;
+    }
+
+    return $accession;
+  }
 }

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -61,7 +61,12 @@ class EUtils {
    * @throws \Exception
    */
   public function get($db, $accession) {
+    $backup_accession = $accession;
     $accession = $this->convertAccessionsToUID($db, $accession);
+
+    if (!$accession) {
+      throw new Exception('Unable to find UID for ' . $db . ':' . $backup_accession);
+    }
 
     if (isset(static::$visited[$db][$accession])) {
       return static::$visited[$db][$accession];
@@ -165,8 +170,7 @@ class EUtils {
       $xml = $response->xml();
 
       $count = (int) $xml->Count;
-      if ($count > 1) {
-        print("warning more than one result");
+      if ($count !== 1) {
         return FALSE;
       }
       $accession = (string) $xml->IdList->Id;

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -72,7 +72,6 @@ class EUtils {
       return static::$visited[$db][$accession];
     }
 
-
     $provider = $this->getResourceProvider($db);
     $provider->addParam('id', $accession);
     if ($db == 'pubmed') {
@@ -81,15 +80,7 @@ class EUtils {
     }
 
     $response = $provider->get();
-    if (!$response->isSuccessful()) {
-      $error_message = $response->hasError() ? $response->errorMessage() : 'Status: ' . $response->status();
-      $variables = ['!db' => $db, '!accession' => $accession];
-      $options = ['print' => TRUE];
-      tripal_report_error('tripal_eutils', TRIPAL_ERROR, 'Cannot fetch NCBI record: !db : !accession', $variables, $options);
-
-      throw new Exception('ERROR Could not make request: ' . $error_message);
-    }
-
+    $this->checkResponseSuccess($response, $db, $accession);
     $xml = $response->xml();
 
     $data = (new EUtilsXMLParserFactory())->get($db)->parse($xml);
@@ -144,29 +135,25 @@ class EUtils {
     return new EFetch($db);
   }
 
-
   /**
    * Checks the accession and converts to uid accession if neccesary.
    *
    * @param string $accession
-   * The accession for the NCBI record.
+   *   The accession for the NCBI record.
    *
    * @return string
    */
   private function convertAccessionsToUID(string $db, string $accession) {
 
-
     if (preg_match("/[a-z]/i", $accession)) {
 
-      //We have letters and need to convert to uid.
-
+      // We have letters and need to convert to uid.
       $provider = new ESearch($db);
       $provider->addParam('retmode', 'xml');
       $provider->addParam('term', $accession);
       $response = $provider->get();
 
-      //TODO handle no response here.
-
+      $this->checkResponseSuccess($response, $db, $accession);
       $xml = $response->xml();
 
       $count = (int) $xml->Count;
@@ -178,4 +165,28 @@ class EUtils {
 
     return $accession;
   }
+
+  /**
+   * Checks that the resource was found.
+   *
+   * @param $response
+   *   Response object.
+   * @param string $db
+   *   NCBI db string.
+   * @param string $accession
+   *   Accession.
+   *
+   * @throws \Exception
+   */
+  private function checkResponseSuccess($response, string $db, string $accession) {
+    if (!$response->isSuccessful()) {
+      $error_message = $response->hasError() ? $response->errorMessage() : 'Status: ' . $response->status();
+      $variables = ['!db' => $db, '!accession' => $accession];
+      $options = ['print' => TRUE];
+      tripal_report_error('tripal_eutils', TRIPAL_ERROR, 'Cannot fetch NCBI record: !db : !accession', $variables, $options);
+
+      throw new Exception('ERROR Could not make request: ' . $error_message);
+    }
+  }
+
 }

--- a/tests/EUtilsTest.php
+++ b/tests/EUtilsTest.php
@@ -43,6 +43,8 @@ class EUtilsTest extends TripalTestCase {
       ['assembly', '557018', '557018'],
       ['assembly', 'dog', FALSE],
       ['assembly', 'DFDSJKFLADSFKDASFFOIHWINBIANBSDFKJASLFKJ', FALSE],
+      ['bioproject', 'PRJNA66853', '66853'],
+      ['biosample', 'SAMN02981385', '2981385']
 
 
     ];

--- a/tests/EUtilsTest.php
+++ b/tests/EUtilsTest.php
@@ -10,10 +10,14 @@ class EUtilsTest extends TripalTestCase {
   // Uncomment to auto start and rollback db transactions per test method.
   use DBTransaction;
 
+  /**
+   * @group eutils
+   * @throws \Exception
+   */
   public function testSettingDB() {
     $connection = new \EUtils();
     $this->expectException('Exception');
-    $connection->get('waffles', ['000000']);
+    $connection->get('waffles', '000000');
   }
 
 
@@ -21,7 +25,6 @@ class EUtilsTest extends TripalTestCase {
    * Accessions with letters arent UIDs and should be converted.
    *
    * @group eutils
-   * @group convert
    * @dataProvider accessionDataProvider
    * @throws \Exception
    */

--- a/tests/EUtilsTest.php
+++ b/tests/EUtilsTest.php
@@ -38,6 +38,10 @@ class EUtilsTest extends TripalTestCase {
     return [
       ['assembly', 'GCF_000184155.1', '557018'],
       ['assembly', '557018', '557018'],
+      ['assembly', 'dog', FALSE],
+      ['assembly', 'DFDSJKFLADSFKDASFFOIHWINBIANBSDFKJASLFKJ', FALSE],
+
+
     ];
   }
 }

--- a/tests/EUtilsTest.php
+++ b/tests/EUtilsTest.php
@@ -16,4 +16,28 @@ class EUtilsTest extends TripalTestCase {
     $connection->get('waffles', ['000000']);
   }
 
+
+  /**
+   * Accessions with letters arent UIDs and should be converted.
+   *
+   * @group eutils
+   * @group convert
+   * @dataProvider accessionDataProvider
+   * @throws \Exception
+   */
+  public function testConvertingAccession($db, $input, $expect) {
+    $connection_master = new \EUtils();
+    $connect = reflect($connection_master);
+    $out = $connect->convertAccessionsToUID($db, $input);
+    $this->assertEquals($expect, $out);
+    sleep(.4);
+  }
+
+  public function accessionDataProvider() {
+
+    return [
+      ['assembly', 'GCF_000184155.1', '557018'],
+      ['assembly', '557018', '557018'],
+    ];
+  }
 }


### PR DESCRIPTION
resolve #62 
pretty happy with this: if the accession has text, we use the esearch to convert it to UID.  From a user standpoint this means athey can enter SAMN00744358 or 00744358!