### PR TITLE
search for accession explicitly and if that fails search for latest only

### DIFF
--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -151,7 +151,7 @@ class EUtils {
       // We have letters and need to convert to uid.
       $provider = new ESearch($db);
       $provider->addParam('retmode', 'xml');
-      $provider->addParam('term', $accession);
+      $provider->addParam('field', 'accession');
       $response = $provider->get();
 
       $this->checkResponseSuccess($response, $db, $accession);
@@ -159,7 +159,20 @@ class EUtils {
 
       $count = (int) $xml->Count;
       if ($count !== 1) {
-        return FALSE;
+
+        $provider = new ESearch($db);
+        $provider->addParam('retmode', 'xml');
+        $provider->addParam('term', $accession . ' AND (latest[filter])');
+        $response = $provider->get();
+        $this->checkResponseSuccess($response, $db, $accession);
+        $xml = $response->xml();
+
+        $count = (int) $xml->Count;
+
+        if ($count !== 1) {
+
+          return FALSE;
+        }
       }
       $accession = (string) $xml->IdList->Id;
     }

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -151,10 +151,11 @@ class EUtils {
       // We have letters and need to convert to uid.
       $provider = new ESearch($db);
       $provider->addParam('retmode', 'xml');
+      $provider->addParam('term', $accession);
       $provider->addParam('field', 'accession');
       $response = $provider->get();
-
       $this->checkResponseSuccess($response, $db, $accession);
+
       $xml = $response->xml();
 
       $count = (int) $xml->Count;


### PR DESCRIPTION
resolves #167 

First it specifies the query is for the accession (fix for `SAMD00093090`).  Then, if that fails, it tries again filtering on latest: `        $provider->addParam('term', $accession . ' AND (latest[filter])');`, resolving `GCA_000648675`.  We have to do it in two queries because the latest filter doesnt appear to be compatible with the field= filter.