### PR TITLE
always set assembly property to genome_assembly correctly.  insert as…

### DIFF
--- a/includes/formatters/EUtilsAssemblyFormatter.inc
+++ b/includes/formatters/EUtilsAssemblyFormatter.inc
@@ -20,6 +20,8 @@ class EUtilsAssemblyFormatter extends EUtilsFormatter {
     try {
       $this->formatBaseRecord($data);
       $this->formatAttributes($data['attributes']);
+      $this->formatXrefs($data['accessions']['assembly']);
+      unset($data['accessions']['assembly']);
       $this->formatLinkedRecords($data['accessions']);
     }
     catch (Exception $exception) {
@@ -174,6 +176,36 @@ class EUtilsAssemblyFormatter extends EUtilsFormatter {
     if ($biosample_found && !$bioproject_found) {
       tripal_set_message('A bioMaterial record is linked, but no BioSample.  Please import the BioSample directly.', TRIPAL_NOTICE);
     }
+  }
+
+
+  private function formatXrefs(array $accessions) {
+
+    $rows =[];
+    $header = ['Database', 'Accession'];
+    foreach ($accessions as $key => $item) {
+
+      $link = $this->getDbLink($item, $key);
+      $rows[] = [$key, $link];
+    }
+
+    if (empty($rows)) {
+      return;
+    }
+
+    $table = theme('table', ['rows' => $rows, 'header' => $header]);
+
+    $this->elements['xrefs'] = [
+      '#type' => 'fieldset',
+      '#title' => 'Cross References',
+      '#collapsible' => TRUE,
+    ];
+    $this->elements['xrefs']['table'] = [
+      '#markup' => $table,
+      '#type' => 'item',
+    ];
+
+
   }
 
 

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -106,10 +106,13 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     $this->base_table = 'analysis';
     $this->base_record_id = $analysis->analysis_id;
 
-    //All assemblies are Genome Assembly.  See ticket 197.
-    
+    // All assemblies are Genome Assembly.  See ticket 197.
     $this->setAnalysisType('Genome Assembly');
     $this->createXMLProp($data['full_ncbi_xml']);
+
+    $this->createAccessions($data['accessions']['assembly']);
+    unset($data['accessions']['assembly']);
+
     $this->createLinkedRecords($data['accessions']);
 
     $biosamples = $data['accessions']['biosamples'] ?? NULL;
@@ -318,10 +321,6 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   private function setAnalysisType(string $type) {
 
-    if (!$type) {
-      return FALSE;
-    }
-
     $term = tripal_get_cvterm(['id' => 'rdfs:type']);
 
     switch ($type) {
@@ -329,7 +328,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
         return $this->createProperty($term->cvterm_id, 'genome_assembly');
 
       default:
-        return FALSE;
+        return $this->createProperty($term->cvterm_id, 'genome_assembly');
     }
   }
 
@@ -364,6 +363,25 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
         }
       }
     }
+  }
+
+  /**
+   * Creates a set of accessions (dbxrefs) attached to the analysis.
+   *
+   * @see \EUtilsRepository::createAccession()
+   *
+   * @param array $accessions
+   *
+   * @return array
+   */
+  private function createAccessions(array $accessions) {
+    $data = [];
+
+    foreach ($accessions as $db => $accession) {
+
+      $data[] = $this->createAccession(['db' => $db, 'value' => $accession]);
+    }
+    return $data;
   }
 
 }

--- a/tests/Repositories/EUtilsAssemblyRepositoryTest.php
+++ b/tests/Repositories/EUtilsAssemblyRepositoryTest.php
@@ -20,6 +20,7 @@ class EUtilsAssemblyRepositoryTest extends TripalTestCase {
    * @group analysis
    * @group assembly
    * @group repository
+   * @group fail
    */
   public function testAssemblyFromXML() {
 

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -36,6 +36,7 @@ function tripal_eutils_install() {
   tripal_eutils_add_dbs();
   tripal_eutils_insert_biosample_attribute_terms();
   tripal_eutils_install_chado_1_4_tables();
+
 }
 
 /**
@@ -197,6 +198,8 @@ function tripal_eutils_add_dbs() {
     'urlprefix' => 'https://www.ncbi.nlm.nih.gov/assembly/{accession}',
     'url' => 'https://www.ncbi.nlm.nih.gov/assembly/',
   ]);
+
+  tripal_eutils_create_dbs_for_assembly_xrefs();
 }
 
 /**
@@ -240,6 +243,28 @@ function tripal_eutils_install_chado_1_4_tables() {
 
 }
 
+
+/**
+ * Creates db entries for keys introduced in hte assembly loader.
+ *
+ */
+function tripal_eutils_create_dbs_for_assembly_xrefs() {
+
+  chado_insert_db([
+    'name' => 'Refseq Assembly',
+    'description' => "A database providing information on the structure of assembled genomes, assembly names and other meta-data, statistical reports, and links to genomic sequence data..",
+    'urlprefix' => 'https://www.ncbi.nlm.nih.gov/assembly/{accession}',
+    'url' => 'https://www.ncbi.nlm.nih.gov/assembly/',
+  ]);
+
+  chado_insert_db([
+    'name' => 'Genbank Assembly',
+    'description' => "A database providing information on the structure of assembled genomes, assembly names and other meta-data, statistical reports, and links to genomic sequence data..",
+    'urlprefix' => 'https://www.ncbi.nlm.nih.gov/assembly/{accession}',
+    'url' => 'https://www.ncbi.nlm.nih.gov/assembly/',
+  ]);
+
+}
 /**
  * Add extra property terms.
  */
@@ -248,12 +273,11 @@ function tripal_eutils_update_7301() {
 
 }
 
-//
-// **
-// * Uninstall the module.
-// */
-// function tripal_hq_uninstall() {
-//  if (db_table_exists('tripal_hq_submission')) {
-//    db_drop_table('tripal_hq_submission');
-//  }
-// }.
+/**
+ * Add extra databases
+ */
+function tripal_eutils_update_7302(){
+  tripal_eutils_create_dbs_for_assembly_xrefs();
+
+}
+


### PR DESCRIPTION
…sembly genbank refseq uids and accessions as xrefs

resolves #196 

![screen shot 2019-02-26 at 5 57 11 pm](https://user-images.githubusercontent.com/7063154/53454529-83a65e80-39f5-11e9-96c9-6eca111736e8.png)

the formatter, and the repository, now treat these keys as _xrefs not as possible linked analysis records.