### PR TITLE
pass job argument to logger so it gets printed

### DIFF
--- a/includes/TripalImporter/EutilsImporter.inc
+++ b/includes/TripalImporter/EutilsImporter.inc
@@ -130,7 +130,9 @@ class EutilsImporter extends TripalImporter {
     $accession = $arguments['accession'];
     $create_linked_records = $arguments['linked_records'];
 
-    tripal_eutils_create_records($db, $accession, $create_linked_records);
+    $job = $this->job;
+
+    tripal_eutils_create_records($db, $accession, $create_linked_records, $job);
 
   }
 

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -41,10 +41,24 @@ class EUtils {
   protected $create_linked_records;
 
   /**
+   * Tripal Job object.
    *
+   * @var TripalJob|null
    */
-  public function __construct($create_linked_records = TRUE) {
+  protected $job;
+
+  /**
+   * EUtils constructor.
+   *
+   * @param bool $create_linked_records
+   *
+   * @param TripalJob|null $job
+   *   Tripal Job object.
+   */
+  public function __construct($create_linked_records = TRUE, $job = NULL) {
     $this->create_linked_records = $create_linked_records;
+
+    $this->job = $job;
   }
 
   /**
@@ -79,9 +93,8 @@ class EUtils {
       $provider->addParam('retmode', 'xml');
     }
 
-    //  TODO:  global static timer.
+    // TODO:  global static timer.
     //  That pauses if we're passing our alloted queries/second.
-
     $response = $provider->get();
     $this->checkResponseSuccess($response, $db, $accession);
     $xml = $response->xml();
@@ -97,7 +110,9 @@ class EUtils {
     $repository = (new EUtilsRepositoryFactory($this->create_linked_records))->get($db);
 
     $variables = ['!db' => $db, '!accession' => $accession];
-    tripal_report_error('tripal_eutils', TRIPAL_INFO, 'Inserting record into Chado: !db: !accession', $variables, ['print' => TRUE]);
+    $job = $this->job;
+    tripal_report_error('tripal_eutils', TRIPAL_INFO, 'Inserting record into Chado: !db: !accession', $variables, ['print' => TRUE, 'job' => $job]);
+
     $record = $repository->create($data);
 
     static::$visited[$db][$accession] = $record;
@@ -226,7 +241,8 @@ class EUtils {
     if (!$response->isSuccessful()) {
       $error_message = $response->hasError() ? $response->errorMessage() : 'Status: ' . $response->status();
       $variables = ['!db' => $db, '!accession' => $accession];
-      $options = ['print' => TRUE];
+      $job = $this->job;
+      $options = ['print' => TRUE, 'job' => $job];
       tripal_report_error('tripal_eutils', TRIPAL_ERROR, 'Cannot fetch NCBI record: !db : !accession', $variables, $options);
 
       throw new Exception('ERROR Could not make request: ' . $error_message);

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -51,7 +51,7 @@ class EUtils {
    * EUtils constructor.
    *
    * @param bool $create_linked_records
-   *
+   *   Records referenced in the XML will spawn new EUtils to import if true.
    * @param TripalJob|null $job
    *   Tripal Job object.
    */
@@ -94,7 +94,7 @@ class EUtils {
     }
 
     // TODO:  global static timer.
-    //  That pauses if we're passing our alloted queries/second.
+    // That pauses if we're passing our alloted queries/second.
     $response = $provider->get();
     $this->checkResponseSuccess($response, $db, $accession);
     $xml = $response->xml();

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -92,10 +92,10 @@ function tripal_eutils_permission() {
  * @param bool $create_linked_records
  *   Whether to create linked records or not.
  */
-function tripal_eutils_create_records(string $db, string $accession, bool $create_linked_records) {
+function tripal_eutils_create_records(string $db, string $accession, bool $create_linked_records, $job = NULL) {
   try {
 
-    $eutils = new EUtils($create_linked_records);
+    $eutils = new EUtils($create_linked_records, $job);
     $eutils->get($db, $accession);
   }
   catch (Exception $exception) {


### PR DESCRIPTION
implement #206 for base record insertion.

I think a big improvement would be to pass the job into the repositories as well- that way, those classes can also log to the job HUD-- this is largely desirable for printing out if a record was alreayd found in the db and wont be re-inserted, as right now that happens "silently"