### PR TITLE
Analysis caching fix for Issue 226

### DIFF
--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -260,7 +260,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    return static::$cache['analysis'][$cachekey] = $analysis;
+    return static::$cache['analysis'][$cacheKey] = $analysis;
   }
 
   /**
@@ -276,8 +276,8 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
 
     // If the analysis is available in our static cache, return it.
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    if (isset(static::$cache['analysis'][$cachekey])) {
-      return static::$cache['analysis'][$cachekey];
+    if (isset(static::$cache['analysis'][$cacheKey])) {
+      return static::$cache['analysis'][$cacheKey];
     }
 
     $exists = db_select('chado.analysis', 't')

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -32,7 +32,6 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     'description',
     'attributes',
     'full_ncbi_xml',
-
   ];
 
   /**
@@ -53,7 +52,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   protected static $cache = [
     'db' => [],
     'accessions' => [],
-    'analysis' => NULL,
+    'analysis' => [],
   ];
 
   /**
@@ -199,7 +198,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function linkOrganism($organism) {
     if (!chado_table_exists('organism_analysis')) {
-      throw new Exception('The organism_analysis linker table doesnt exist.  No way to link this organism.');
+      throw new Exception("The organism_analysis linker table doesn't exist.  No way to link this organism.");
     }
 
     $result = db_select('chado.organism_analysis', 't')
@@ -260,7 +259,8 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->execute()
       ->fetchObject();
 
-    return static::$cache['analysis'] = $analysis;
+    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
+    return static::$cache['analysis'][$cachekey] = $analysis;
   }
 
   /**
@@ -273,9 +273,11 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   public function getAnalysis() {
 
     $base = $this->base_fields;
+
     // If the analysis is available in our static cache, return it.
-    if (isset(static::$cache['analysis'])) {
-      return static::$cache['analysis'];
+    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
+    if (isset(static::$cache['analysis'][$cachekey])) {
+      return static::$cache['analysis'][$cachekey];
     }
 
     $exists = db_select('chado.analysis', 't')
@@ -287,9 +289,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     if ($exists) {
-
-      // TODO: we need to carefully validate the returned analysis.  We want to be sure we arent overwriting another existing analysis....
-      return static::$cache['analysis'] = $exists;
+      return static::$cache['analysis'][$cacheKey] = $exists;
     }
 
     return NULL;

--- a/includes/repositories/EUtilsRepositoryFactory.inc
+++ b/includes/repositories/EUtilsRepositoryFactory.inc
@@ -51,7 +51,7 @@ class EUtilsRepositoryFactory implements EUtilsFactoryInterface {
     $ldb = strtolower($db);
 
     if (!isset($this->repositories[$ldb])) {
-      throw new Exception('Enable to find a repository for the provided DB: ' . $db);
+      throw new Exception('Unable to find a repository for the provided DB: ' . $db);
     }
     return new $this->repositories[$ldb]($this->create_linked_records);
   }


### PR DESCRIPTION
This is a fix for Issue #226, where if more than one genome assembly is loaded and they are both processed in the same drush run, everything gets linked to the first generated analysis. 

A unique identifier is now used for caching the analysis record.

A small number of minor spelling corrections are also included.