### PR TITLE
Tripal eutils.module.fix

### DIFF
--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -260,7 +260,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    return static::$cache['analysis'][$cachekey] = $analysis;
+    return static::$cache['analysis'][$cacheKey] = $analysis;
   }
 
   /**
@@ -276,8 +276,8 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
 
     // If the analysis is available in our static cache, return it.
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    if (isset(static::$cache['analysis'][$cachekey])) {
-      return static::$cache['analysis'][$cachekey];
+    if (isset(static::$cache['analysis'][$cacheKey])) {
+      return static::$cache['analysis'][$cacheKey];
     }
 
     $exists = db_select('chado.analysis', 't')

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -260,7 +260,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    return static::$cache['analysis'][$cacheKey] = $analysis;
+    return static::$cache['analysis'][$cachekey] = $analysis;
   }
 
   /**
@@ -276,8 +276,8 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
 
     // If the analysis is available in our static cache, return it.
     $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    if (isset(static::$cache['analysis'][$cacheKey])) {
-      return static::$cache['analysis'][$cacheKey];
+    if (isset(static::$cache['analysis'][$cachekey])) {
+      return static::$cache['analysis'][$cachekey];
     }
 
     $exists = db_select('chado.analysis', 't')

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -75,7 +75,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
 
     // Program and program version come from # Assembly method:
     // $data['attributes']['ftp_attributes']['# Assembly method:'].
-    $method_string = $data['attributes']['ftp_attributes']['# Assembly method:'];
+    $method_string = $data['attributes']['ftp_attributes']['# Assembly method:'] ?? 'Assembly method was not reported';
 
     // TODO: what do we want to do here?  Parse out the version from the
     // assembly program?  But what if we have multiple programs and

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -32,7 +32,6 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     'description',
     'attributes',
     'full_ncbi_xml',
-
   ];
 
   /**
@@ -53,7 +52,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   protected static $cache = [
     'db' => [],
     'accessions' => [],
-    'analysis' => NULL,
+    'analysis' => [],
   ];
 
   /**
@@ -199,7 +198,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function linkOrganism($organism) {
     if (!chado_table_exists('organism_analysis')) {
-      throw new Exception('The organism_analysis linker table doesnt exist.  No way to link this organism.');
+      throw new Exception("The organism_analysis linker table doesn't exist.  No way to link this organism.");
     }
 
     $result = db_select('chado.organism_analysis', 't')
@@ -260,7 +259,8 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->execute()
       ->fetchObject();
 
-    return static::$cache['analysis'] = $analysis;
+    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
+    return static::$cache['analysis'][$cachekey] = $analysis;
   }
 
   /**
@@ -273,9 +273,11 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   public function getAnalysis() {
 
     $base = $this->base_fields;
+
     // If the analysis is available in our static cache, return it.
-    if (isset(static::$cache['analysis'])) {
-      return static::$cache['analysis'];
+    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
+    if (isset(static::$cache['analysis'][$cachekey])) {
+      return static::$cache['analysis'][$cachekey];
     }
 
     $exists = db_select('chado.analysis', 't')
@@ -287,9 +289,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     if ($exists) {
-
-      // TODO: we need to carefully validate the returned analysis.  We want to be sure we arent overwriting another existing analysis....
-      return static::$cache['analysis'] = $exists;
+      return static::$cache['analysis'][$cacheKey] = $exists;
     }
 
     return NULL;

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -32,6 +32,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
     'description',
     'attributes',
     'full_ncbi_xml',
+
   ];
 
   /**
@@ -52,7 +53,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   protected static $cache = [
     'db' => [],
     'accessions' => [],
-    'analysis' => [],
+    'analysis' => NULL,
   ];
 
   /**
@@ -198,7 +199,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
    */
   public function linkOrganism($organism) {
     if (!chado_table_exists('organism_analysis')) {
-      throw new Exception("The organism_analysis linker table doesn't exist.  No way to link this organism.");
+      throw new Exception('The organism_analysis linker table doesnt exist.  No way to link this organism.');
     }
 
     $result = db_select('chado.organism_analysis', 't')
@@ -259,8 +260,7 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->execute()
       ->fetchObject();
 
-    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    return static::$cache['analysis'][$cachekey] = $analysis;
+    return static::$cache['analysis'] = $analysis;
   }
 
   /**
@@ -273,11 +273,9 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
   public function getAnalysis() {
 
     $base = $this->base_fields;
-
     // If the analysis is available in our static cache, return it.
-    $cacheKey = implode(':', [$base['name'], $base['program'], $base['programversion']]);
-    if (isset(static::$cache['analysis'][$cachekey])) {
-      return static::$cache['analysis'][$cachekey];
+    if (isset(static::$cache['analysis'])) {
+      return static::$cache['analysis'];
     }
 
     $exists = db_select('chado.analysis', 't')
@@ -289,7 +287,9 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       ->fetchObject();
 
     if ($exists) {
-      return static::$cache['analysis'][$cacheKey] = $exists;
+
+      // TODO: we need to carefully validate the returned analysis.  We want to be sure we arent overwriting another existing analysis....
+      return static::$cache['analysis'] = $exists;
     }
 
     return NULL;

--- a/includes/repositories/EUtilsRepositoryFactory.inc
+++ b/includes/repositories/EUtilsRepositoryFactory.inc
@@ -51,7 +51,7 @@ class EUtilsRepositoryFactory implements EUtilsFactoryInterface {
     $ldb = strtolower($db);
 
     if (!isset($this->repositories[$ldb])) {
-      throw new Exception('Enable to find a repository for the provided DB: ' . $db);
+      throw new Exception('Unable to find a repository for the provided DB: ' . $db);
     }
     return new $this->repositories[$ldb]($this->create_linked_records);
   }

--- a/includes/repositories/EUtilsRepositoryFactory.inc
+++ b/includes/repositories/EUtilsRepositoryFactory.inc
@@ -51,7 +51,7 @@ class EUtilsRepositoryFactory implements EUtilsFactoryInterface {
     $ldb = strtolower($db);
 
     if (!isset($this->repositories[$ldb])) {
-      throw new Exception('Unable to find a repository for the provided DB: ' . $db);
+      throw new Exception('Enable to find a repository for the provided DB: ' . $db);
     }
     return new $this->repositories[$ldb]($this->create_linked_records);
   }

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -92,6 +92,6 @@ function tripal_eutils_create_records(string $db, string $accession, bool $creat
   }
   catch (Exception $exception) {
 
-    tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), ['print' => TRUE, 'job' => $job]);
+    tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
   }
 }


### PR DESCRIPTION
Pull request for Issue #228 

The missing parameter (an empty array) is added to the call to tripal_report_error()