### PR TITLE
233 namespace conflict

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,3 +51,10 @@ Permissions
 ~~~~~~~~~~~~
 
 This module only defines one permission: ``access tripal_eutils admin``.  This permission will allow users to use the admin form to directly insert Chado records into the database given NCBI accessions.  Because this form adds data to your db, we suggest reserving it for administrators.
+
+
+Updating
+~~~~~~~~~~~~
+As of database update 7303, the database and controlled vocabulary for terms used by this module have been converted from ncbi_properties to NCBI Biosample Attributes.
+This was done to match the Tripal Biomaterial module's schema, which also overhauled its terminology, coincidentally also in database update 7303.
+Instructions for updating to the new schema can be found in the `Tripal Biomaterial module <https://github.com/dsenalik/tripal_analysis_expression/>`_. There is a "Module Updating" section that applies to both of these modules.

--- a/includes/TagMapper.inc
+++ b/includes/TagMapper.inc
@@ -116,20 +116,20 @@ class TagMapper {
     // Please keep this alphabetized for sanity.
     // If updated, please also delete/update terms in the install file.
     return [
-      'age' => $this->getTerm(['id' => 'ncbi_properties:age']),
+      'age' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:age']),
       'bio_material' => NULL,
-      'breed' => $this->getTerm(['id' => 'ncbi_properties:breed']),
-      'collection_date' => $this->getTerm(['id' => 'ncbi_properties:collection_date']),
-      'cultivar' => $this->getTerm(['id' => 'ncbi_properties:cultivar']),
-      'dev_stage' => $this->getTerm(['id' => 'ncbi_properties:dev_stage']),
-      'geo_loc_name' => $this->getTerm(['id' => 'ncbi_properties:geo_loc_name']),
-      'isolation_source' => $this->getTerm(['id' => 'ncbi_properties:isolation_source']),
-      'orgmod_note' => $this->getTerm(['id' => 'ncbi_properties:orgmod_note']),
-      'phenotype' => $this->getTerm(['id' => 'ncbi_properties:phenotype']),
-      'sex' => $this->getTerm(['id' => 'ncbi_properties:sex']),
-      'strain' => $this->getTerm(['id' => 'ncbi_properties:strain']),
-      'sub_species' => $this->getTerm(['id' => 'ncbi_properties:sub_species']),
-      'tissue' => $this->getTerm(['id' => 'ncbi_properties:tissue']),
+      'breed' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:breed']),
+      'collection_date' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:collection_date']),
+      'cultivar' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:cultivar']),
+      'dev_stage' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:dev_stage']),
+      'geo_loc_name' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:geo_loc_name']),
+      'isolation_source' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:isolation_source']),
+      'orgmod_note' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:orgmod_note']),
+      'phenotype' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:phenotype']),
+      'sex' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:sex']),
+      'strain' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:strain']),
+      'sub_species' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:sub_species']),
+      'tissue' => $this->getTerm(['id' => 'NCBI_BioSample_Attributes:tissue']),
     ];
   }
 

--- a/includes/repositories/EUtilsAssemblyRepository.inc
+++ b/includes/repositories/EUtilsAssemblyRepository.inc
@@ -130,10 +130,10 @@ class EUtilsAssemblyRepository extends EUtilsRepository {
       // for now just use local.
       // $mapper->lookupAttribute($key)
       $term = tripal_insert_cvterm([
-        'id' => 'ncbi_properties:' . $key,
+        'id' => 'NCBI_BioSample_Attributes:' . $key,
         'name' => $key,
         'def' => '',
-        'cv_name' => 'ncbi_properties',
+        'cv_name' => 'NCBI BioSample Attributes',
       ]);
       $this->createProperty($term->cvterm_id, $value);
     }

--- a/includes/repositories/EUtilsBioSampleRepository.inc
+++ b/includes/repositories/EUtilsBioSampleRepository.inc
@@ -208,7 +208,7 @@ class EUtilsBioSampleRepository extends EUtilsRepository {
       $value = $attribute['value'];
 
       // TODO: the term lookup class should handle this instead.
-      $cvterm = chado_get_cvterm(['id' => 'ncbi_properties:' . $term_name]);
+      $cvterm = chado_get_cvterm(['id' => 'NCBI_BioSample_Attributes:' . $term_name]);
       $cvterm_id = $cvterm->cvterm_id;
       $this->createProperty($cvterm_id, $value);
     }

--- a/tests/BiosamplePropertyLookupTest.php
+++ b/tests/BiosamplePropertyLookupTest.php
@@ -31,7 +31,7 @@ class BiosamplePropertyLookupTest extends TripalTestCase {
    * @group propertylookup
    */
   public function testTermsInserted() {
-    $term = chado_get_cvterm(['id' => 'ncbi_properties:fao_class']);
+    $term = chado_get_cvterm(['id' => 'NCBI_BioSample_Attributes:fao_class']);
     $this->assertObjectHasAttribute('cvterm_id', $term);
     $this->assertObjectHasAttribute('name', $term);
     $this->assertEquals('FAO classification', $term->name);

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -164,8 +164,8 @@ function tripal_eutils_add_dbs() {
 
   chado_insert_db([
     'name' => 'NCBI_BioSample_Attributes',
-    'description' => 'Attribute and property terms for NCBI.',
-    'url' => 'http://www.ncbi.nlm.nih.gov/',
+    'description' => 'This database provides, in XML format, the listing of attribute names for biosamples housed in NCBI.',
+    'url' => 'https://www.ncbi.nlm.nih.gov/biosample/docs/attributes',
   ]);
 
   chado_insert_db([
@@ -302,7 +302,7 @@ function tripal_eutils_convert_terms() {
   $new_cv_id = $new_cv_id['cv_id'];
   print_r("New: NCBI_BioSample_Attributes cv_id: " . $new_cv_id . "\n");
 
-
+  /*
   // Find all  occurences of cvterms with the old cv_id and update them to the new one
   $num_updated = db_update('chado.cvterm')
   ->fields(array(
@@ -312,7 +312,11 @@ function tripal_eutils_convert_terms() {
   ->execute();
 
   print_r("Updated " . $num_updated . " terms from ncbi_properties to NCBI_BioSample_Attributes.\n");
-  
+  */
+
+  // Insert the terms from NCBI's Sample XML file within the new CV (via the $new_cv_id)
+  tripal_eutils_insert_biosample_attribute_terms();
+
 }
 
 /**

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -40,7 +40,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
     [
       'id' => 'NCBI_BioSample_Attributes:samples provided by',
       'name' => 'Samples provided by',
-      'def' => '',
+      'definition' => '',
       'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
@@ -49,7 +49,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
     [
       'id' => 'NCBI_BioSample_Attributes:Publication',
       'name' => 'Publication',
-      'def' => '',
+      'definition' => '',
       'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
@@ -57,7 +57,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
     [
       'id' => 'NCBI_BioSample_Attributes:note',
       'name' => 'Note',
-      'def' => 'Misc. free text.',
+      'definition' => 'Misc. free text.',
       'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
@@ -81,7 +81,7 @@ function tripal_eutils_insert_biosample_attribute_terms() {
       [
         'id' => 'NCBI_BioSample_Attributes:' . $machine_name,
         'name' => $attributes['label'],
-        'def' => $attributes['def'],
+        'definition' => $attributes['def'],
         'cv_name' => 'NCBI BioSample Attributes',
       ]
     );

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -9,8 +9,8 @@
  */
 function tripal_eutils_install() {
 
-  chado_insert_cv('ncbi_properties',
-    'The ncbi BioSample properties CV is downloaded from https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/?format=xml.');
+  chado_insert_cv('NCBI BioSample Attributes',
+    'The ncbi BioSample Attributes CV is downloaded from https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/?format=xml.');
 
   chado_insert_cvterm([
     'id' => 'local:full_ncbi_xml',
@@ -26,9 +26,9 @@ function tripal_eutils_install() {
 
   chado_insert_cvterm(
     [
-      'id' => 'ncbi_properties:submitter_provided_accession',
+      'id' => 'NCBI_BioSample_Attributes:submitter_provided_accession',
       'name' => 'submitter_provided_accession',
-      'cv_name' => 'ncbi_properties',
+      'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
 
@@ -46,27 +46,27 @@ function tripal_eutils_insert_extra_biosample_terms() {
 
   tripal_insert_cvterm(
     [
-      'id' => 'ncbi_properties:samples provided by',
+      'id' => 'NCBI_BioSample_Attributes:samples provided by',
       'name' => 'Samples provided by',
       'def' => '',
-      'cv_name' => 'ncbi_properties',
+      'cv_name' => 'NCBI BioSample Attribute',
     ]
   );
 
   tripal_insert_cvterm(
     [
-      'id' => 'ncbi_properties:Publication',
+      'id' => 'NCBI_BioSample_Attributes:Publication',
       'name' => 'Publication',
       'def' => '',
-      'cv_name' => 'ncbi_properties',
+      'cv_name' => 'NCBI BioSample Attribute',
     ]
   );
   tripal_insert_cvterm(
     [
-      'id' => 'ncbi_properties:note',
+      'id' => 'NCBI_BioSample_Attributes:note',
       'name' => 'Note',
       'def' => 'Misc. free text.',
-      'cv_name' => 'ncbi_properties',
+      'cv_name' => 'NCBI BioSample Attribute',
     ]
   );
 }
@@ -75,7 +75,8 @@ function tripal_eutils_insert_extra_biosample_terms() {
  *Adds attribute terms for properties.
  */
 function tripal_eutils_insert_biosample_attribute_terms() {
-
+  // @todo Download the most up-to-date file and use that instead,
+  // the same way the Analysis Expression module does it.
   $file = __DIR__ . '/mappings/biosample/xml_releases/11-30-18.xml';
 
   $lookup = new \BiosamplePropertyLookup($file);
@@ -86,10 +87,10 @@ function tripal_eutils_insert_biosample_attribute_terms() {
 
     tripal_insert_cvterm(
       [
-        'id' => 'ncbi_properties:' . $machine_name,
+        'id' => 'NCBI_BioSample_Attributes:' . $machine_name,
         'name' => $attributes['label'],
         'def' => $attributes['def'],
-        'cv_name' => 'ncbi_properties',
+        'cv_name' => 'NCBI BioSample Attribute',
       ]
     );
   }
@@ -162,7 +163,7 @@ function tripal_eutils_add_dbs() {
   ]);
 
   chado_insert_db([
-    'name' => 'ncbi_properties',
+    'name' => 'NCBI_BioSample_Attributes',
     'description' => 'Attribute and property terms for NCBI.',
     'url' => 'http://www.ncbi.nlm.nih.gov/',
   ]);

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -49,7 +49,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
       'id' => 'NCBI_BioSample_Attributes:samples provided by',
       'name' => 'Samples provided by',
       'def' => '',
-      'cv_name' => 'NCBI BioSample Attribute',
+      'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
 
@@ -58,7 +58,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
       'id' => 'NCBI_BioSample_Attributes:Publication',
       'name' => 'Publication',
       'def' => '',
-      'cv_name' => 'NCBI BioSample Attribute',
+      'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
   tripal_insert_cvterm(
@@ -66,7 +66,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
       'id' => 'NCBI_BioSample_Attributes:note',
       'name' => 'Note',
       'def' => 'Misc. free text.',
-      'cv_name' => 'NCBI BioSample Attribute',
+      'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
 }
@@ -90,7 +90,7 @@ function tripal_eutils_insert_biosample_attribute_terms() {
         'id' => 'NCBI_BioSample_Attributes:' . $machine_name,
         'name' => $attributes['label'],
         'def' => $attributes['def'],
-        'cv_name' => 'NCBI BioSample Attribute',
+        'cv_name' => 'NCBI BioSample Attributes',
       ]
     );
   }
@@ -268,6 +268,38 @@ function tripal_eutils_create_dbs_for_assembly_xrefs() {
   ]);
 
 }
+
+/**
+ * Convert terms from ncbi_properties to NCBI_BioSample_Attributes
+ */
+function tripal_eutils_convert_terms() {
+  // Check if the ncbi_utilities name exists within the cv table, if so, get the cv_id
+  $query = "SELECT cv_id FROM chado.cv WHERE name LIKE 'ncbi_properties'";
+  $results = db_query($query);
+  
+  $cv_id = $results->fetchAssoc();
+  $cv_id = $cv_id['cv_id'];
+  print_r("Current: " . $cv_id . "\n");
+
+  // Get the $cv_id of the new NCBI_BioSample_Attributes
+  $query = "SELECT cv_id FROM chado.cv WHERE name LIKE 'NCBI_BioSample_Attributes'";
+  $results = db_query($query);
+
+  $new_cv_id = $results->fetchAssoc();
+  $new_cv_id = $new_cv_id['cv_id'];
+  print_r($new_cv_id);
+
+  // Find all  occurences of cvterms with this cv_id
+  /*
+  $num_updated = db_update('chado.cv')
+  ->fields(array(
+    'cv_id' => $new_cv_id,
+  ))
+  ->condition('cv_id', $cv_id, '=')
+  ->execute();
+  */
+}
+
 /**
  * Add extra property terms.
  */
@@ -282,4 +314,11 @@ function tripal_eutils_update_7301() {
 function tripal_eutils_update_7302(){
   tripal_eutils_create_dbs_for_assembly_xrefs();
 
+}
+
+/**
+ * Convert terms from ncbi_properties to NCBI_BioSample_Attributes
+ */
+function tripal_eutils_update_7303() {
+  tripal_eutils_convert_terms();
 }

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -36,7 +36,7 @@ function tripal_eutils_install() {
  */
 function tripal_eutils_insert_extra_biosample_terms() {
 
-  tripal_insert_cvterm(
+  chado_insert_cvterm(
     [
       'id' => 'NCBI_BioSample_Attributes:samples provided by',
       'name' => 'Samples provided by',
@@ -45,7 +45,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
     ]
   );
 
-  tripal_insert_cvterm(
+  chado_insert_cvterm(
     [
       'id' => 'NCBI_BioSample_Attributes:Publication',
       'name' => 'Publication',
@@ -53,7 +53,7 @@ function tripal_eutils_insert_extra_biosample_terms() {
       'cv_name' => 'NCBI BioSample Attributes',
     ]
   );
-  tripal_insert_cvterm(
+  chado_insert_cvterm(
     [
       'id' => 'NCBI_BioSample_Attributes:note',
       'name' => 'Note',
@@ -77,7 +77,7 @@ function tripal_eutils_insert_biosample_attribute_terms() {
 
   foreach ($terms as $machine_name => $attributes) {
 
-    tripal_insert_cvterm(
+    chado_insert_cvterm(
       [
         'id' => 'NCBI_BioSample_Attributes:' . $machine_name,
         'name' => $attributes['label'],

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -302,18 +302,6 @@ function tripal_eutils_convert_terms() {
   $new_cv_id = $new_cv_id['cv_id'];
   print_r("New: NCBI_BioSample_Attributes cv_id: " . $new_cv_id . "\n");
 
-  /*
-  // Find all  occurences of cvterms with the old cv_id and update them to the new one
-  $num_updated = db_update('chado.cvterm')
-  ->fields(array(
-    'cv_id' => $new_cv_id,
-  ))
-  ->condition('cv_id', $cv_id, '=')
-  ->execute();
-
-  print_r("Updated " . $num_updated . " terms from ncbi_properties to NCBI_BioSample_Attributes.\n");
-  */
-
   // Insert the terms from NCBI's Sample XML file within the new CV (via the $new_cv_id)
   tripal_eutils_insert_biosample_attribute_terms();
 

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -24,18 +24,10 @@ function tripal_eutils_install() {
     'cv_name' => 'local',
   ]);
 
-  chado_insert_cvterm(
-    [
-      'id' => 'NCBI_BioSample_Attributes:submitter_provided_accession',
-      'name' => 'submitter_provided_accession',
-      'cv_name' => 'NCBI BioSample Attributes',
-    ]
-  );
-
-
   tripal_eutils_add_dbs();
   tripal_eutils_insert_biosample_attribute_terms();
   tripal_eutils_install_chado_1_4_tables();
+  tripal_eutils_convert_terms();
 
 }
 
@@ -284,6 +276,15 @@ function tripal_eutils_convert_terms() {
     'description' => 'Attribute and property terms for NCBI.',
     'url' => 'http://www.ncbi.nlm.nih.gov/',
   ]);
+
+  chado_insert_cvterm(
+    [
+      'id' => 'NCBI_BioSample_Attributes:submitter_provided_accession',
+      'name' => 'submitter_provided_accession',
+      'cv_name' => 'NCBI BioSample Attributes',
+    ],
+    ['update_existing' => false]
+  );
 
 
   // Check if the ncbi_utilities name exists within the cv table, if so, get the cv_id

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -273,13 +273,26 @@ function tripal_eutils_create_dbs_for_assembly_xrefs() {
  * Convert terms from ncbi_properties to NCBI_BioSample_Attributes
  */
 function tripal_eutils_convert_terms() {
+
+  // Insert the new cv and db entries, but not the terms from the XML (this means we can't just call
+  // tripal_eutils_install() again).
+  chado_insert_cv('NCBI BioSample Attributes',
+    'The ncbi BioSample Attributes CV is downloaded from https://www.ncbi.nlm.nih.gov/biosample/docs/attributes/?format=xml.');
+
+  chado_insert_db([
+    'name' => 'NCBI_BioSample_Attributes',
+    'description' => 'Attribute and property terms for NCBI.',
+    'url' => 'http://www.ncbi.nlm.nih.gov/',
+  ]);
+
+
   // Check if the ncbi_utilities name exists within the cv table, if so, get the cv_id
   $query = "SELECT cv_id FROM chado.cv WHERE name LIKE 'ncbi_properties'";
   $results = db_query($query);
   
   $cv_id = $results->fetchAssoc();
   $cv_id = $cv_id['cv_id'];
-  print_r("Current: " . $cv_id . "\n");
+  print_r("Current ncbi_properties cv_id: " . $cv_id . "\n");
 
   // Get the $cv_id of the new NCBI_BioSample_Attributes
   $query = "SELECT cv_id FROM chado.cv WHERE name LIKE 'NCBI_BioSample_Attributes'";
@@ -287,17 +300,19 @@ function tripal_eutils_convert_terms() {
 
   $new_cv_id = $results->fetchAssoc();
   $new_cv_id = $new_cv_id['cv_id'];
-  print_r($new_cv_id);
+  print_r("New: NCBI_BioSample_Attributes cv_id: " . $new_cv_id . "\n");
 
-  // Find all  occurences of cvterms with this cv_id
-  /*
-  $num_updated = db_update('chado.cv')
+
+  // Find all  occurences of cvterms with the old cv_id and update them to the new one
+  $num_updated = db_update('chado.cvterm')
   ->fields(array(
     'cv_id' => $new_cv_id,
   ))
   ->condition('cv_id', $cv_id, '=')
   ->execute();
-  */
+
+  print_r("Updated " . $num_updated . " terms from ncbi_properties to NCBI_BioSample_Attributes.\n");
+  
 }
 
 /**


### PR DESCRIPTION
Upon install, newly agreed upon names for the cv and db will be installed and the NCBI terms will be inserted using those values.
If an existing install is detected, the new names will be installed and the existing terms updated and not re-inserted.

Satisfies the first two objectives in this [issue](https://github.com/NAL-i5K/tripal_eutils/issues/233 "Issue 233")