### PR TITLE
Issue 241 Allow loading multiple records

### DIFF
--- a/includes/TripalImporter/EutilsImporter.inc
+++ b/includes/TripalImporter/EutilsImporter.inc
@@ -46,7 +46,8 @@ class EutilsImporter extends TripalImporter {
     ];
 
     $form['accession'] = [
-      '#type' => 'textfield',
+      '#type' => 'textarea',
+      '#rows' => 1,
       '#title' => t('NCBI Accession Number(s)'),
       '#description' => t('Valid examples: (BioSample 744358 120060 SAMN02261463), (Assembly 91111, 751381, GCA_000516895.1), (BioProject 12384, 394253, 66853, PRJNA185471).
                        Separate multiple accessions with comma, semicolon, or space.'),

--- a/includes/TripalImporter/EutilsImporter.inc
+++ b/includes/TripalImporter/EutilsImporter.inc
@@ -26,9 +26,9 @@ class EutilsImporter extends TripalImporter {
   public function form($form, &$form_state) {
 
     $form['instructions'] = [
-      '#markup' => t('<p>Please enter an accession and specify a database.</p>
-                  <p>Press the <b>Preview Record</b> button to view the 
-                  retrieved data and metadata.  Pressing <b>Create Chado 
+      '#markup' => t('<p>Please enter one or more accessions and specify a database.</p>
+                  <p>Press the <b>Preview First Record</b> button to view the
+                  retrieved data and metadata.  Pressing <b>Import NCBI
                   Record</b> will create the record.</p>'),
     ];
 
@@ -47,13 +47,14 @@ class EutilsImporter extends TripalImporter {
 
     $form['accession'] = [
       '#type' => 'textfield',
-      '#title' => t('NCBI Accession Number'),
-      '#description' => t('Valid examples: (BioSample 744358 120060 SAMN02261463), (Assembly 91111, 751381, GCA_000516895.1), (BioProject 12384, 394253, 66853, PRJNA185471)'),
+      '#title' => t('NCBI Accession Number(s)'),
+      '#description' => t('Valid examples: (BioSample 744358 120060 SAMN02261463), (Assembly 91111, 751381, GCA_000516895.1), (BioProject 12384, 394253, 66853, PRJNA185471).
+                       Separate multiple accessions with comma, semicolon, or space.'),
     ];
 
     $form['callback'] = [
       '#type' => 'button',
-      '#value' => "Preview Record",
+      '#value' => "Preview First Record",
     ];
 
     if (isset($form_state['values']['parsed'])) {
@@ -93,7 +94,7 @@ class EutilsImporter extends TripalImporter {
     $vals = $form_state['values'];
 
     $db = $vals['db'];
-    $accession = $vals['accession'];
+    $accession = trim($vals['accession']);
 
     if (!$db) {
       form_set_error('db', 'please select a valid db');
@@ -107,6 +108,8 @@ class EutilsImporter extends TripalImporter {
       return;
     }
 
+    // If multiple accessions, only preview the first one.
+    $accession = preg_replace('/[;, ].*/', '', $accession);
     $connection = new \EUtils();
     try {
       $connection->setPreview();
@@ -127,12 +130,12 @@ class EutilsImporter extends TripalImporter {
   public function run() {
     $arguments = $this->arguments['run_args'];
     $db = $arguments['db'];
-    $accession = $arguments['accession'];
+    $accessions = $arguments['accession'];
     $create_linked_records = $arguments['linked_records'];
 
     $job = $this->job;
 
-    tripal_eutils_create_records($db, $accession, $create_linked_records, $job);
+    tripal_eutils_create_records($db, $accessions, $create_linked_records, $job);
   }
 
 }

--- a/includes/resources/EUtils.inc
+++ b/includes/resources/EUtils.inc
@@ -112,8 +112,16 @@ class EUtils {
 
     $repository = (new EUtilsRepositoryFactory($this->create_linked_records))->get($db);
     $repository->setJob($job);
-    $variables = ['!db' => $db, '!accession' => $accession];
-    tripal_report_error('tripal_eutils', TRIPAL_INFO, 'Inserting record into Chado: !db: !accession', $variables, ['print' => TRUE, 'job' => $job]);
+    // For SAMD type of BioSamples the accession is very different from the number part
+    // of the SAMD, so display both when different.
+    if ($backup_accession != $accession) {
+      $orig_accession = ' ('.$backup_accession.')';
+    }
+    else {
+      $orig_accession = '';
+    }
+    $variables = ['!db' => $db, '!accession' => $accession, '!orig_accession' => $orig_accession];
+    tripal_report_error('tripal_eutils', TRIPAL_INFO, 'Inserting record into Chado: !db: !accession!orig_accession', $variables, ['print' => TRUE, 'job' => $job]);
 
     $record = $repository->create($data);
 

--- a/includes/xml_parsers/EUtilsBioProjectParser.inc
+++ b/includes/xml_parsers/EUtilsBioProjectParser.inc
@@ -54,7 +54,7 @@ class EUtilsBioProjectParser implements EUtilsParserInterface {
         case 'ProjectDescr':
 
           // Information about the project itself.  Includes title, description.
-          $name_string = (string) $child->Name . ': ' . (string) $child->Title;
+          $name_string = implode(': ', array_filter([(string) $child->Name, (string) $child->Title]));
           $info['name'] = $name_string;
           $info['description'] = (string) $child->Description;
 

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -87,14 +87,26 @@ function tripal_eutils_permission() {
 function tripal_eutils_create_records(string $db, string $accession, bool $create_linked_records, $job = NULL) {
   $accs = preg_split('/[,; ]+/', trim($accession));
   foreach ($accs as $acc) {
-    try {
+    $attempts = 3;
+    $success = false;
+    while ((!$success) and ($attempts)) {
+      try {
 
-      $eutils = new EUtils($create_linked_records, $job);
-      $eutils->get($db, $acc);
-    }
-    catch (Exception $exception) {
+        $eutils = new EUtils($create_linked_records, $job);
+        $eutils->get($db, $acc);
+        $success = true;
+      }
+      catch (Exception $exception) {
 
-      tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+        if ($attempts > 1) {
+          tripal_report_error('tripal_eutils', TRIPAL_WARNING, 'Download error, retrying '.$exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+          sleep(1);
+        }
+        else {
+          tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+        }
+      }
+      $attempts--;
     }
   }
 }

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -80,18 +80,21 @@ function tripal_eutils_permission() {
  * @param string $db
  *   The database name (eg, biosample, assembly or bioproject).
  * @param string $accession
- *   The numeric accession.
+ *   The numeric accession, or accessions separated by delimiter of comma, semicolon, or space.
  * @param bool $create_linked_records
  *   Whether to create linked records or not.
  */
 function tripal_eutils_create_records(string $db, string $accession, bool $create_linked_records, $job = NULL) {
-  try {
+  $accs = preg_split('/[,; ]+/', trim($accession));
+  foreach ($accs as $acc) {
+    try {
 
-    $eutils = new EUtils($create_linked_records, $job);
-    $eutils->get($db, $accession);
-  }
-  catch (Exception $exception) {
+      $eutils = new EUtils($create_linked_records, $job);
+      $eutils->get($db, $acc);
+    }
+    catch (Exception $exception) {
 
-    tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+      tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+    }
   }
 }


### PR DESCRIPTION
For Issue #241 
The relatively simple changes here allow loading of multiple NCBI records at the same time, by just separating them with a delimiter of comma, semicolon, or space.
The preview button only previews the first record if more than one is supplied.
I also added a ```trim()``` so that if the user includes a space before or after the accession, nothing unexpected happens.