### PR TITLE
Issue 232 add retry loop for ftp downloads

### DIFF
--- a/includes/resources/EFTP.inc
+++ b/includes/resources/EFTP.inc
@@ -32,7 +32,24 @@ class EFTP {
   public function setURL($url) {
 
     $this->url = $url;
-    $file = file_get_contents($url);
+    // Because of occasional intermittent problems with FTP downloads, wrap
+    // this download in a retry loop with a 3 second timeout and 20 retries.
+    $maxtries = 20;
+    $original_timeout = ini_get('default_socket_timeout');
+    ini_set('default_socket_timeout', 3);
+    $file = '';
+    while (($maxtries) and (!$file)) {
+      $file = file_get_contents($url);
+      $maxtries--;
+      if ((!$file) and ($maxtries)) {
+        tripal_report_error('tripal_eutils', TRIPAL_WARNING, 'FTP download error, retrying !maxtries more times',
+          ['!maxtries' => $maxtries], ['print' => TRUE, 'job' => $this->job]);
+      }
+    }
+    // Set FTP timeout back to default
+    if ($original_timeout) {
+      ini_set('default_socket_timeout', $original_timeout);
+    }
     if (!$file) {
       throw new Exception('Unable to connect to FTP resource: ' . $url);
     }

--- a/tripal_eutils.module
+++ b/tripal_eutils.module
@@ -98,12 +98,19 @@ function tripal_eutils_create_records(string $db, string $accession, bool $creat
       }
       catch (Exception $exception) {
 
+        $message = $exception->getMessage();
+        // Distinguish between download error and SQL error, e.g. from reloading same assembly twice.
+        // Download error: "ERROR Could not make request: Status: 400"
+        // SQL error: "SQLSTATE[25P02]: In failed sql transaction: 7 ERROR:  current transaction is aborted, commands ignored until end of transaction block"
+        if (preg_match('/SQL/', $message)) {
+          $attempts = 1;
+        }
         if ($attempts > 1) {
-          tripal_report_error('tripal_eutils', TRIPAL_WARNING, 'Download error, retrying '.$exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+          tripal_report_error('tripal_eutils', TRIPAL_WARNING, 'Download error, retrying '.$message, [], ['print' => TRUE, 'job' => $job]);
           sleep(1);
         }
         else {
-          tripal_report_error('tripal_eutils', TRIPAL_ERROR, $exception->getMessage(), [], ['print' => TRUE, 'job' => $job]);
+          tripal_report_error('tripal_eutils', TRIPAL_ERROR, $message, [], ['print' => TRUE, 'job' => $job]);
         }
       }
       $attempts--;


### PR DESCRIPTION
Issue #232 

This pull request implements a retry loop for FTP downloads, used when loading an assembly.

Because FTP errors seem to occur early on, change the timeout from the default of 60 seconds to just 3 seconds, so that retry attempts do not have to wait so long.