### PR TITLE
Remove tripal_manage_analyses dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,19 +9,17 @@ Tripal EUtilities requires:
 - Tripal 3
 - PHP >= 7.0
 - Drupal 7
-- `Tripal Manage Analyses <https://github.com/statonlab/tripal_manage_analyses.git>`_
 
 Installation
 ------------
 
-``tripal_eutils`` and its dependency ``tripal_manage_analyses`` are not available for deployment via Drush and must be installed via git.
+``tripal_eutils`` is not available for deployment via Drush and must be installed via git.
 
 .. code-block:: shell
 
   cd [location of your custom or contrib modules]
-  git clone https://github.com/statonlab/tripal_manage_analyses.git
   git clone https://github.com/NAL-i5K/tripal_eutils.git
-  drush pm-enable tripal_manage_analyses tripal_eutils -y
+  drush pm-enable tripal_eutils -y
 
 
 Chado

--- a/tripal_eutils.info
+++ b/tripal_eutils.info
@@ -3,4 +3,4 @@ description = Provides linker field alternatives and tripalImporters for adding 
 project = tripal_eutils
 package = Tripal Extensions
 core = 7.x
-dependencies[] = tripal_manage_analyses
+dependencies[] = tripal

--- a/tripal_eutils.install
+++ b/tripal_eutils.install
@@ -134,6 +134,70 @@ function tripal_eutils_schema() {
     ],
   ];
 
+  // Linker table between biomaterials and projects.
+  $schema['biomaterial_project'] = [
+    'fields' => [
+      'biomaterial_project_id' => ['type' => 'serial', 'not null' => TRUE],
+      'biomaterial_id' => ['type' => 'int', 'not null' => TRUE],
+      'project_id' => ['type' => 'int', 'not null' => TRUE],
+    ],
+    'primary key' => ['biomaterial_project_id'],
+    'foreign keys' => [
+      'biomaterial' => [
+        'table' => 'biomaterial',
+        'columns' => [
+          'biomaterial_id' => 'biomaterial_id',
+        ],
+      ],
+      'project' => [
+        'table' => 'project',
+        'columns' => [
+          'project_id' => 'project_id',
+        ],
+      ],
+    ],
+    'indexes' => [
+      'biomaterial_project_idx1' => ['biomaterial_id'],
+      'biomaterial_project_idx2' => ['project_id'],
+    ],
+    'unique keys' => [
+      'biomaterial_project_unique_uq1' => ['biomaterial_id', 'project_id'],
+    ],
+  ];
+
+  // Linker table between organisms and analyses.
+  // This table schema is identical to the tripal_manage_analyses module schema.
+  $schema['organism_analysis'] = [
+    'fields' => [
+      'organism_analysis_id' => ['type' => 'serial', 'not null' => TRUE],
+      'organism_id' => ['type' => 'int', 'not null' => TRUE],
+      'analysis_id' => ['type' => 'int', 'not null' => TRUE],
+    ],
+    'primary key' => ['organism_analysis_id'],
+    'foreign keys' => [
+      'organism' => [
+        'table' => 'organism',
+        'columns' => [
+          'organism_id' => 'organism_id',
+        ],
+      ],
+      'analysis' => [
+        'table' => 'analysis',
+        'columns' => [
+          'analysis_id' => 'analysis_id',
+        ],
+      ],
+    ],
+    'indexes' => [
+      'organism_analysis_idx1' => ['organism_id'],
+      'organism_analysis_idx2' => ['analysis_id'],
+
+    ],
+    'unique keys' => [
+      'organism_analysis_unique_uq1' => ['organism_id', 'analysis_id'],
+    ],
+  ];
+
   return $schema;
 }
 
@@ -198,50 +262,21 @@ function tripal_eutils_add_dbs() {
   tripal_eutils_create_dbs_for_assembly_xrefs();
 }
 
+}
+
 /**
  * Adds Chado linker tables this module needs.
  *
  * These tables will be in the Chado 1.4 release so let's add them here for now.
  */
 function tripal_eutils_install_chado_1_4_tables() {
-
-  $schema = [
-    'fields' => [
-      'biomaterial_project_id' => ['type' => 'serial', 'not null' => TRUE],
-      'biomaterial_id' => ['type' => 'int', 'not null' => TRUE],
-      'project_id' => ['type' => 'int', 'not null' => TRUE],
-    ],
-    'primary key' => ['biomaterial_project_id'],
-    'foreign keys' => [
-      'biomaterial' => [
-        'table' => 'biomaterial',
-        'columns' => [
-          'biomaterial_id' => 'biomaterial_id',
-        ],
-      ],
-      'project' => [
-        'table' => 'project',
-        'columns' => [
-          'project_id' => 'project_id',
-        ],
-      ],
-    ],
-    'indexes' => [
-      'biomaterial_project_idx1' => ['biomaterial_id'],
-      'biomaterial_project_idx2' => ['project_id'],
-    ],
-    'unique keys' => [
-      'biomaterial_project_unique_uq1' => ['biomaterial_id', 'project_id'],
-    ],
-  ];
-
-  chado_create_custom_table('biomaterial_project', $schema, TRUE, NULL, FALSE);
-
+  $schema = tripal_eutils_schema();
+  chado_create_custom_table('biomaterial_project', $schema['biomaterial_project'], TRUE, NULL, FALSE);
+  chado_create_custom_table('organism_analysis', $schema['organism_analysis'], TRUE, NULL, FALSE);
 }
 
-
 /**
- * Creates db entries for keys introduced in hte assembly loader.
+ * Creates db entries for keys introduced in the assembly loader.
  *
  */
 function tripal_eutils_create_dbs_for_assembly_xrefs() {


### PR DESCRIPTION
Issue #248 
This pull request duplicates the creation of the ```chado.organism_analysis``` table from the tripal_manage_analyses module, thus eliminating the dependency on that module.