### PR TITLE
Issue 258 define version = 7.x-1.2

### DIFF
--- a/tripal_eutils.info
+++ b/tripal_eutils.info
@@ -3,4 +3,5 @@ description = Provides linker field alternatives and tripalImporters for adding 
 project = tripal_eutils
 package = Tripal Extensions
 core = 7.x
+version = 7.x-1.2
 dependencies[] = tripal


### PR DESCRIPTION
## Issue #258 
This defines the module current state as version ```7.x-1.2``` in ```tripal_eutils.info``` which previously did not define a version number.